### PR TITLE
Extend role models

### DIFF
--- a/Tooling-Landscape/Unanimous-Understanding/OSS-Tooling-Landscape-Glossary.md
+++ b/Tooling-Landscape/Unanimous-Understanding/OSS-Tooling-Landscape-Glossary.md
@@ -26,11 +26,12 @@ Example: [ClearlyDefined](https://clearlydefined.io/)
 
 ## Company Internal
 
-### Source Code Repository
-Systems or services that provide source code. This is typically (also) a version control system. For the compliance tooling, typically the source code is needed as a folder on a file share, i.e., the source code is already checked out by, e.g., the Continuous Integration infrastructure. 
+### Artifact Repository
+A system or service providing (binary) software artifacts and metadata stored in a defined directory structure which is used to retrieve artifacts during a build process. This is used as a cache for the external Artifact Repository to ensure the availability of all components used within the company, it is also the storage for the build software artifacts of the company, used in the Continuous Integration Infrastructure to store the build results.
+Example: [Archiva](https://archiva.apache.org/index.cgi)
 
-### Continuous Integration/Deployment Infrastructure (CI/CD)
-Systems or services that orchestrate the build and deployment process for a software project and executes workflows triggered by different kind of events. The CI/CD infrastructure typically runs software builds and executes further build steps like testing and the compliance checks
+### Black-/Whitelist
+In some cases it may make sense to provide a list of accetable (white) or not acceptable (black) licenses or components. Thus a developer aiming to use a new component may verify against this list whether his aim will violate any company/project rules. In particular critical components even a "whitelisting requirement" could be issued, so a competent sponsor may ensure that only allowed components will be applied. Modern tooling should support automated verification of such lists or a whitelist enforcement. 
 
 ### Build Tool
 A system that builds a software project and creates the binaries and executables for the software. During this process, the build technology has a technology dependent way to identify and provide dependencies needed to build and run the software. This information is used to run the compliance check on the project.
@@ -38,31 +39,34 @@ A system that builds a software project and creates the binaries and executables
 ### Compliance Checker
 A set of systems or services that are executed on the identified dependencies of a project to provide the metadata for the identified components and to run a compliance check according to defined criteria, such as license compatibility, known security violations, company policies.
 
-### FOSS Compliance Bundle Generator
-A tool that creates all the necessary documentation needed for the distribution of a software, such a document with all used components there licenses and copyrights, or a source code bundle with all the FOSS sources used in the project. The FOSS bundle is the artifact to be bundled with the delivered product to fulfill license obligations found in FOSS licenses.
-
 ### Component Analysis Service
 Dedicated tools and services which provide license information for source code and/or binaries. The tools used follow different approaches. Some get the information by looking it up in a database. Some do source code scans for copyright and license information in comments. Others scan the source code concerning copyrighted snippets. The clearing also contains a step in which the results are approved according to company criteria.
-
-### License & Copyright Scanner
-A tool that analyses source code to identify license and copyright information.
-Example: [Fossology](https://www.fossology.org/), [Scancode Toolkit](https://github.com/nexB/scancode-toolkit)
-
-### Artifact Repository
-A system or service providing (binary) software artifacts and metadata stored in a defined directory structure which is used to retrieve artifacts during a build process. This is used as a cache for the external Artifact Repository to ensure the availability of all components used within the company, it is also the storage for the build software artifacts of the company, used in the Continuous Integration Infrastructure to store the build results.
-Example: [Archiva](https://archiva.apache.org/index.cgi)
-
-### Security Vulnerability Assessment
-A set of tools and services which map known vulnerabilities from an external database to components used in products and assess the relevance and exploitability of the vulnerability concerning the usage pattern of the component in question.
-
-### Product Metadata Repository
-Software products and most software components are built from other software components. The Product Metadata Repository contains this relationship information to enable the management of dependencies over the life cycle of the software.
-Example: [Eclipse SW360](https://projects.eclipse.org/proposals/sw360)
 
 ### Component Metadata Repository
 A system or service that stores metadata about used software components (esp. FOSS). This includes licenses, copyrights, known vulnerabilitites and information, that is needed to do export classifications (ECCN), such as information about the contained cryptographic functionality. The information is used within the compliance checker to aquire the metadata for the identified components, to assess the compilation of dependent components and to provide the information for the creation of the FOSS bundle (i.e., the artifacts needed for the distribution of a software). The Component Metadata Repository can be linked to an external FOSS Metadata Database to retrieve commonly known information and make it usable within the organization. Also Security Vulnerability Database and other sources for e.g. export classification-relevant data, can be linked to retrieve the necessary information and to make it available within the company.
 Example: [Eclipse SW360](https://projects.eclipse.org/proposals/sw360)
 
+### Continuous Integration/Deployment Infrastructure (CI/CD)
+Systems or services that orchestrate the build and deployment process for a software project and executes workflows triggered by different kind of events. The CI/CD infrastructure typically runs software builds and executes further build steps like testing and the compliance checks
+
+### FOSS Compliance Bundle Generator
+A tool that creates all the necessary documentation needed for the distribution of a software, such a document with all used components there licenses and copyrights, or a source code bundle with all the FOSS sources used in the project. The FOSS bundle is the artifact to be bundled with the delivered product to fulfill license obligations found in FOSS licenses.
+
+### License & Copyright Scanner
+A tool that analyses source code to identify license and copyright information.
+Example: [Fossology](https://www.fossology.org/), [Scancode Toolkit](https://github.com/nexB/scancode-toolkit)
+
 ### License Metadata Repository
 A list of all FOSS (and commercial?) licenses in use within an organization with all necessary metadata like implied obligations. It may use a Public License Master Database and a License Obligation Database for basic information enriched by the company for internal use.
 Example: [Eclipse SW360](https://projects.eclipse.org/proposals/sw360)
+
+### Product Metadata Repository
+Software products and most software components are built from other software components. The Product Metadata Repository contains this relationship information to enable the management of dependencies over the life cycle of the software.
+Example: [Eclipse SW360](https://projects.eclipse.org/proposals/sw360)
+
+### Security Vulnerability Assessment
+A set of tools and services which map known vulnerabilities from an external database to components used in products and assess the relevance and exploitability of the vulnerability concerning the usage pattern of the component in question.
+
+### Source Code Repository
+Systems or services that provide source code. This is typically (also) a version control system. For the compliance tooling, typically the source code is needed as a folder on a file share, i.e., the source code is already checked out by, e.g., the Continuous Integration infrastructure. 
+

--- a/User-Stories/Compliance-Manager-User-Stories/ComplianceManager.md
+++ b/User-Stories/Compliance-Manager-User-Stories/ComplianceManager.md
@@ -16,7 +16,7 @@ Typically this will result in the following kind of ```tasks```:
 * Support teams in open sourcing their own components
 * Review compliance applications and provide approvals, respectively suitable guidance
 
-A Compliance Manager will ```escalate```to the Open Source Board or the Senior Management Sponsor.
+A Compliance Manager will ```escalate```to the Open Source Board or the Senior Sponsor.
 
 A strong dependency esists to the toolchain used.
 

--- a/User-Stories/Compliance-Manager-User-Stories/ComplianceManager.md
+++ b/User-Stories/Compliance-Manager-User-Stories/ComplianceManager.md
@@ -1,0 +1,46 @@
+#Compliance Manager
+This describes the role of a Compliance Manager. This is a role with suitable legal understanding so that he will be able to interpret the legal situation and assess the circumstances accordingly so that he will be able to judge the consequences from obligations respectively support teams / POs in identifying suitable measures to remain compliant. According to OCv2.0 specification, this role may be staffed by external resources.
+
+##Responsibilities, tasks and role
+The ```primary goal```of the Compliance Manager should be to achieve compliance. He is the advocate of the 3rd party license holders within the company. 
+
+Thus the role will be held ```accountable``` for 
+* Compliance of all open source used  within the products, that received his approval
+* Suitability of the general|all|project specific black/whitelists 
+* Creation, maintenance and governance of the Open Source Policy 
+
+Typically this will result in the following kind of ```tasks```:
+* Generate, publish, promote and maintain the corporate Open Source Policy
+* Operate (organize, manage agenda, etc.) the Open Source Board meetings
+* Provide support to the projects in determining legal obligations
+* Support teams in open sourcing their own components
+* Review compliance applications and provide approvals, respectively suitable guidance
+
+A Compliance Manager will ```escalate```to the Open Source Board or the Senior Management Sponsor.
+
+A strong dependency esists to the toolchain used.
+
+In a real life scenario the role of the Compliance Manager could be mapped to:
+* A Product Manager or a Product Owner with reasonable legal expertise 
+* In a decentral approach the role could be taken by especially educated Senior Developers
+* Specialized internal role, in a kind of staff function
+* Hired external capacity
+
+##Epic
+As a Compliance Manager
+I want to ensure compliance
+so that all software product leaving the house will be free of legal compliance risk | complaint
+
+###UC#01: Provide and promote Open Source Policy 
+
+###UC#02: Organize Open Source Board Meetings
+
+###UC#03: Support projects in understand legal circumstances
+
+###UC#04: Support projects in deriving legal obligations
+
+###UC#05: Help project in resolving legal obligations
+
+###UC#06: Guide teams in identifying contributions
+
+###UC#07: Approve/reject compliace requests

--- a/User-Stories/Developer-User-Stories/Developer.md
+++ b/User-Stories/Developer-User-Stories/Developer.md
@@ -1,2 +1,29 @@
 #Developer
-The developer represents actually all participants that address compliance primaryly from the (IT) technical perspective.
+The developer represents actually all participants who are primaryly interested in the compliance topic from the (IT) technical perspective. This must not necesarily be a developer role but might also be a designer or writer. 
+
+##Responsibilities, tasks and role
+The ```primary goal``` of this role should be to provide software at a minimum technical and legal risk. 
+
+Thus this role will be ```accountable``` for:
+* Take care, that no third party copyright will be removed or changed
+* Completeness of components listed in Bill of materials
+* Alert, if/that legal circumstances are about to change (e.g. new usage scenario)
+
+This typically results in the following ```tasks```: 
+* Ensure (automated) build processes will be integrated with a scanning solution
+* Prepare audit readyness of applied open source components
+* Change or fix components as requested by PO role
+* Provide understanding of compliance requirements (e.g. from OS policy)
+* Provide understanding of challenges of contributing to OS projects
+* Provide upstream feedback / support / contributions accoding to contribution policy
+* Support OS audits
+
+Therefor the most critical ```success factors``` are:
+* Understanding of Open Source Policy (and awareness of it)
+* Communication skill to convince team members of keeping the repository clean
+
+The role requires a strong acceptance and standing in the team as compliance must not always be the most confortable way. (It's not a choice, it's just good manufacturing practise) Also the complexity of the tasks will highly depend on the degree of automation the tool chain has achieved. The will escalate to either PO or Compliance Manager.
+
+In a real life scenario, this role would be taken by a:
+* Senior Software Developer
+* Software Architect

--- a/User-Stories/Developer-User-Stories/Developer.md
+++ b/User-Stories/Developer-User-Stories/Developer.md
@@ -1,0 +1,2 @@
+#Developer
+The developer represents actually all participants that address compliance primaryly from the (IT) technical perspective.

--- a/User-Stories/PM-User-Stories/PM-user-stories.md
+++ b/User-Stories/PM-User-Stories/PM-user-stories.md
@@ -1,4 +1,4 @@
-#Product Owner (PO) / Project Manager (PM) user stories
+#Project Manager (PM) user stories
 We assume this role as a principal role compared to a developer. Thus this player has the right to task the developer (agent) and influences the priotization of the agents work. Typically such a role is a team lead or project manager or in modern words a product owner. For ease of read, we will title the role PO, konwing that this simplification will not cover all details associated with the different role models. But from a compliance perspective the models can be treated as equivalent.
 
 ##Responsibilites, tasks and role
@@ -10,7 +10,7 @@ Thus this role will be ```accountable``` for:
 * Completeness of files/data/code to be assessed and delivered within the scope of this project
 
 This typically results in the follwing ```tasks```:
-* Ensure code is scanned on a regular basis - optimally as part of the CI/CD-chain
+* Ensure code is scanned for composition on a regular basis - optimally as part of the CI/CD-chain
 * Ensure that _all_ components _and_ resources comprised within the solution will be captured/covered by the scans (incl. runtime components)
 * Initiate appropriate measures to cope with obligations and provide associated documentation
 * Initiate measures to cope with violations and warnings
@@ -19,10 +19,10 @@ This typically results in the follwing ```tasks```:
 
 Therefor the most ```critical success factors``` of theis role are:
 * Understanding of the Open Source Policy
-* Willingness to provide a proper and sound documentation
+* Willingness to provide a proper and sound documentation (at min. composition and compliance, some cases (e.g. MDD) might require even backgrounds, supplier data, usage scenarios, etc.)
 * Determine the legal circumstances to correctly interpret the legal obligations resulting from open source usage
 
-This role does not have a direct report. The dotted line most likely will be the associated ```Compliance Manager``` for the project. To overcome discrepancies between Compliance Manager and PO, it is suggested to escalate to the ```Open Source Board```
+This role does not have a direct report in this scenario. A kind of dotted line mihgt be the associated ```Compliance Manager``` for the project, because these two should work together where the Compliance Manager finally has to confirm compliance. Thus this role naturally has some authority over the PM. To overcome discrepancies between Compliance Manager and PM, it is suggested to escalate to the ```Open Source Board```
 
 The role has a strong dependency towards the ```Open Source Policy``` and the provided ```Tooling Environment```. For this exercise, we may assume a tooling chain like the one proposed will be available.
 
@@ -35,7 +35,7 @@ In a real life environment, this role may be taken by any of the following role 
 * Senior Developer
 
 ## Epic
-As a PO 
+As a PM 
 I want my product to be compliant
 so that neither my team nor my organization will face any problems resulting from unwanted or unattended open source usage
 

--- a/User-Stories/PO-PM-User-Stories/PO-user-stories.md
+++ b/User-Stories/PO-PM-User-Stories/PO-user-stories.md
@@ -1,7 +1,7 @@
 #Product Owner (PO) / Project Manager (PM) user stories
 We assume this role as a principal role compared to a developer. Thus this player has the right to task the developer (agent) and influences the priotization of the agents work. Typically such a role is a team lead or project manager or in modern words a product owner. For ease of read, we will title the role PO, konwing that this simplification will not cover all details associated with the different role models. But from a compliance perspective the models can be treated as equivalent.
 
-## Responsibilites, Tasks and Role
+##Responsibilites, tasks and role
 The ```primary goal``` of this role is to deliver a software solution while minimizing all related risks. This may comprise security, export controls or the incompliance with obligations resulting from the application of open source components. 
 
 Thus this role will be ```accountable``` for:
@@ -9,7 +9,7 @@ Thus this role will be ```accountable``` for:
 * Arrange and provide all relevnat tasks to cope with resulting obligations
 * Completeness of files/data/code to be assessed and delivered within the scope of this project
 
-This typically results in the follwing tasks:
+This typically results in the follwing ```tasks```:
 * Ensure code is scanned on a regular basis - optimally as part of the CI/CD-chain
 * Ensure that _all_ components _and_ resources comprised within the solution will be captured/covered by the scans (incl. runtime components)
 * Initiate appropriate measures to cope with obligations and provide associated documentation
@@ -17,7 +17,7 @@ This typically results in the follwing tasks:
 * Initiate approval requests
 * Escalate questionnable components/licenses to Compliance Manager/OS board
 
-Therefor the most critical success factors of theis role are:
+Therefor the most ```critical success factors``` of theis role are:
 * Understanding of the Open Source Policy
 * Willingness to provide a proper and sound documentation
 * Determine the legal circumstances to correctly interpret the legal obligations resulting from open source usage

--- a/User-Stories/PO-PM-User-Stories/PO-user-stories.md
+++ b/User-Stories/PO-PM-User-Stories/PO-user-stories.md
@@ -1,0 +1,60 @@
+#Product Owner (PO) / Project Manager (PM) user stories
+We assume this role as a principal role compared to a developer. Thus this player has the right to task the developer (agent) and influences the priotization of the agents work. Typically such a role is a team lead or project manager or in modern words a product owner. For ease of read, we will title the role PO, konwing that this simplification will not cover all details associated with the different role models. But from a compliance perspective the models can be treated as equivalent.
+
+## Responsibilites, Tasks and Role
+The ```primary goal``` of this role is to deliver a software solution while minimizing all related risks. This may comprise security, export controls or the incompliance with obligations resulting from the application of open source components. 
+
+Thus this role will be ```accountable``` for:
+* Execution of all reuired tasks to provide a risk minimized software solutions
+* Arrange and provide all relevnat tasks to cope with resulting obligations
+* Completeness of files/data/code to be assessed and delivered within the scope of this project
+
+This typically results in the follwing tasks:
+* Ensure code is scanned on a regular basis - optimally as part of the CI/CD-chain
+* Ensure that _all_ components _and_ resources comprised within the solution will be captured/covered by the scans (incl. runtime components)
+* Initiate appropriate measures to cope with obligations and provide associated documentation
+* Initiate measures to cope with violations and warnings
+* Initiate approval requests
+* Escalate questionnable components/licenses to Compliance Manager/OS board
+
+Therefor the most critical success factors of theis role are:
+* Understanding of the Open Source Policy
+* Willingness to provide a proper and sound documentation
+* Determine the legal circumstances to correctly interpret the legal obligations resulting from open source usage
+
+This role does not have a direct report. The dotted line most likely will be the associated ```Compliance Manager``` for the project. To overcome discrepancies between Compliance Manager and PO, it is suggested to escalate to the ```Open Source Board```
+
+The role has a strong dependency towards the ```Open Source Policy``` and the provided ```Tooling Environment```. For this exercise, we may assume a tooling chain like the one proposed will be available.
+
+In a real life environment, this role may be taken by any of the following role models:
+* Product Manager
+* Product Owner
+* Project Manager
+* SCRUM Master
+* Dev-Team Manager
+* Senior Developer
+
+## Epic
+As a PO 
+I want my product to be compliant
+so that neither my team nor my organization will face any problems resulting from unwanted or unattended open source usage
+
+###UC0#1: Provide architecture overview of solution
+
+###UC#02: Ensure continuos scanning of new components (CI/CD integration)
+
+###UC#03: Ensure completeness of components covered
+
+###UC#04: Determine legal cricumstances
+
+###UC#05: Determine resulting obligations
+
+###UC#06: Ensure obligations will be met / provide documentation
+
+###UC#07: Initiate resolution of conflicts
+
+###UC#08: Escalate unclear or critical aspects
+
+###UC#09: Ensure confirmation from legal side (approval)
+
+

--- a/User-Stories/README.md
+++ b/User-Stories/README.md
@@ -1,5 +1,5 @@
 ## User Stories
-This directory contains the user stories of all different users an their roles interacting with the functional blocks of the compliance toolchain
+This directory contains the user stories of all different users and their roles interacting with the functional blocks of the compliance toolchain
 
 
 ## Structure

--- a/User-Stories/README.md
+++ b/User-Stories/README.md
@@ -1,9 +1,13 @@
 ## User Stories
 This directory contains the user stories of all different users and their roles interacting with the functional blocks of the compliance toolchain
 
-
 ## Structure
 For each user/role a dedicated directory exists. It serves as a bucket for all user stories of that particular role. Further each directory contains also one epic of the user interacting with the functional blocks, which can be seen as an input to derive more detailed user stories.
+
+## Roles & Users
+Positions and titles are manifold across different companies. Thus it will be difficult to describe all potential users of such a solution. To cope with this, we suggest to describe typical roles and map them to potential job descriptions. This will allow to remain with a few roles but cover all kind of flows between the different roles.
+
+We suggest a role model with three roles interacting hirarchically as two encapsulated principal-agent models: A normative principal (Compliance Manager) that tasks several tactical systems (POs/PMs) which by themselves act as principals in relation to a group of operative systems (Developer).
 
 ## License
 All the content in this sub-tree is licensed under CC-BY-SA-4.0


### PR DESCRIPTION
I provided a few role descriptions. Besides the role descriptions I have added tasks, responsibilities and potential mappings to job role names. As we might not find a common understanding of roles across companies, the idea is to have an OC-toolchain-specific abstraction, which then can be mapped into operational reality. 
This might sound more complex than it is, however, please feel free to extend and add tasks, which I would want to further outline in a 2nd step. 