### PR TITLE
Transferred the capability slide contents 1:1 from OC_ToolingChain_v1.5.7

### DIFF
--- a/Tooling-Landscape/Capabilities/approval_flow.md
+++ b/Tooling-Landscape/Capabilities/approval_flow.md
@@ -1,0 +1,8 @@
+| Approval Flow         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Ensure that the outgoing documentation fits the purpose |
+| Responsibilities | • Provide approval flow appropriate for audit |
+| Tasks            | • Track all legally relevant changes to products and packages <br>• Identify authors of change<br>• Provide compliance status and overview<br>• Allow to approve or reject an approval request<br>• Document/archive all decisions (auditing)<br>• Support for different roles / instances of approval flows |
+| Input            | • Artifacts to be approved and approval type (e.g. security, compliance, etc.)   |
+| Output           | • State of compliance analysis for approval request<br>• Approval / Rejection documentation  |
+| Comments         | • The approval by a dedicated, skilled resource (Compliance Manager) combined with the automation support for all prior steps reduces the need for Compliance Managers<br>• Could be used for other objects, e.g. completeness of list of packages, etc.|

--- a/Tooling-Landscape/Capabilities/audit_log.md
+++ b/Tooling-Landscape/Capabilities/audit_log.md
@@ -1,0 +1,10 @@
+| Audit Log         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Maintain log of changes and user actions (create accountability) |
+| Responsibilities | • Ensure traceability of configuration changes<br>• Ensure tracing and archiving of all user actions/decisions for auditing purposes |
+| Tasks            | • Track user activity and changes in settings, especially legal settings<br>• Track and archive user decisions and related context to enable auditing<br>• Confirmation of completeness (e.g. by project owner)<br>• Derive configuration status at a certain point in history |
+| Input            | • User actions / events   |
+| Output           | • History of changes with actors<br>• History of changes, configurations and decisions that lead to a particular compliance artefact (e.g. version number of scanner, scan config, etc.)  |
+| Comments         | |
+
+

--- a/Tooling-Landscape/Capabilities/case_data_analyzer.md
+++ b/Tooling-Landscape/Capabilities/case_data_analyzer.md
@@ -1,0 +1,8 @@
+| Case Data Analyzer         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Interpret all collected case data in given context and determine deltas  |
+| Responsibilities | • Identify obligations, violations and warnings |
+| Tasks            | • Check for completeness of information<br>• Identify missing information (e.g. missing Copyright information)<br>• Determine rights and obligations, compare with requirements from business context |
+| Input            | • Case Data (see [13. ToolChain Capabilities - Case Data (Structure of Solution...](case_data_collector.md))<br>• Policy & Rules<br>• Legal interpretation  |
+| Output           | • Analysis result for further processing |
+| Comments         | • Review after re-draw of model |

--- a/Tooling-Landscape/Capabilities/case_data_collector.md
+++ b/Tooling-Landscape/Capabilities/case_data_collector.md
@@ -1,0 +1,8 @@
+| Case Data Collector         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Provide bracket for all compliance relevant information that is not directly related to source of a product / distribution item  |
+| Responsibilities | • Ensure completeness of case documentation |
+| Tasks            | • Collect all product specific information, including package change & linkage status (via history)<br>• Follow the release cycle of a particular product, e.g. approvals<br>• Build canvas for reporting and analysis of a given composition & in a given situation<br>• Versioning of analysis results to map with input situations |
+| Input            | • Business context (business model, distribution, external contractual obligations, etc.)<br>• Software Bill of Materials (SBOM) + Component meta data (see [Package Metadata Repo](package_metadata_repository.md))<br>• External components, e.g. runtime environments, middleware or resources (as part of solution)<br>• Type of delivery/distribution (binary, source (oss), source (proprietary & oss), source (proprietary, oss , COTS and combinations of these) <br>• Participants / Stakeholders (audience)<br>• Approval Feedback  |
+| Output           | • Status Overview<br>• History of events and changes to context and meta data |
+| Comments         |  |

--- a/Tooling-Landscape/Capabilities/compliance_artefact_generator.md
+++ b/Tooling-Landscape/Capabilities/compliance_artefact_generator.md
@@ -1,0 +1,8 @@
+| Compliance Artefact Generator         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Support provisioning of compliance documentation |
+| Responsibilities | • Ensure legally compliant documentation |
+| Tasks            | • Generate documentation according to requirements<br>• Support Compliance Managers in completing the documentation<br>• Assemble documentation parts, e.g. written offer, license texts, copyrights, modification statement, etc.<br>• Link documentation with objects (version management / binary links)<br>• Provide documentation in machine readable export formats, e.g. JSON, SPDX, CyDX, etc.  |
+| Input            | • List of versioned packages to be documented (BoMs) and their meta data<br>• Legal requirements with respect to particular circumstances   |
+| Output           | • Stub with all documentation requirements <br>• Pre-assembled stub with all existing information (e.g. from repositories) <br>• Identified TODOs for missing bits  |
+| Comments         | |

--- a/Tooling-Landscape/Capabilities/dependency_analyzer_binary.md
+++ b/Tooling-Landscape/Capabilities/dependency_analyzer_binary.md
@@ -1,0 +1,8 @@
+| Dependency Analyzer (Binary)          | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Provide composition analysis of a software binary |
+| Responsibilities | • Determine all packages and dependencies used within this binary  |
+| Tasks            | • Download binary (if required)<br>• Unpack binary<br>• Assess content and determine used packages/components<br>• Collect information and assemble Bill of Materials<br>• Provide Bill of Materials (e.g. as SPDX)<br>• Provide link between BoM and scanned artefact, e.g. binary repo ID<br>• Hash to identify the binary scanned should be generated and archived  |
+| Input            | • Binary or link to binary location   |
+| Output           | • Bill of Materials (BoM) for particular binary<br>• Status of processing (e.g. errors, inclompleteness, failures in processing) |
+| Comments         |  |

--- a/Tooling-Landscape/Capabilities/dependency_analyzer_container.md
+++ b/Tooling-Landscape/Capabilities/dependency_analyzer_container.md
@@ -1,0 +1,8 @@
+| Dependency Analyzer (Container)          | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Provide composition analysis of a container |
+| Responsibilities | • Determine all packages and dependencies used within this container  |
+| Tasks            | • Download container (if necessary)<br>• Assess container content/structure and determine used packages/components<br>• Collect information and assemble Bill of Materials<br>• Provide Bill of Materials (e.g. as SPDX)<br>• Provide link between BoM and scanned container, e.g. Repo + image ID + tag<br>• Hash to identify the scanned container should be generated and archived  |
+| Input            | • Container or link to container location  |
+| Output           | • Bill of Materials (BoM) for particular container<br>• Status of processing (e.g. errors, incompleteness, failures in processing) |
+| Comments         |  |

--- a/Tooling-Landscape/Capabilities/dependency_analyzer_source.md
+++ b/Tooling-Landscape/Capabilities/dependency_analyzer_source.md
@@ -1,0 +1,8 @@
+| Dependency Analyzer (Source)          | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Provide composition analysis of software to be built from these sources |
+| Responsibilities | • Determine all packages and dependencies (incl. transitive) used to build the software<br>• Determine the way of linking of dependencies  |
+| Tasks            | • Integrate with build process (CI/CD)<br>• Determine composition (_complete_ Bill of Materials)<br>• Provide output for further analysis, e.g. as SPDX<br>• Provide link between scanned source and BoM information, e.g. Commit ID  |
+| Input            | • Build description, e.g. POM or requirements.txt   |
+| Output           | • Bill of Materials (BoM) for particular build   |
+| Comments         | Analysis and dependency resolution is highly language specific. Thus a language specific implementation might be required<br>Discussion: Would it make sense to declare a task or responsibility to stop CI/CD in sit of violation? |

--- a/Tooling-Landscape/Capabilities/input_condition_management.md
+++ b/Tooling-Landscape/Capabilities/input_condition_management.md
@@ -1,0 +1,8 @@
+| Input Condition Management         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Determine that all copyright holders of commits finally grant rights and will not claim back  |
+| Responsibilities | • Prevent code from entering the repository without the commiter having agreed to the terms seeked by repo-owner  |
+| Tasks            | • Link confirmation into Pull-request <br>• Provide sort of proof that code commited to repo went through this process<br>• Log event and confirmations of commiters   |
+| Input            | • Automation event  |
+| Output           | • „Confirmation“ or „break“ event<br>• Log entry  |
+| Comments         | • One option could be to apply CLA-Assistant by SAP |

--- a/Tooling-Landscape/Capabilities/legal_solver.md
+++ b/Tooling-Landscape/Capabilities/legal_solver.md
@@ -1,0 +1,8 @@
+| Legal Solver         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Determine legal rights and obligations resulting from the usage of the listed packages within the project context |
+| Responsibilities | • Provide compliance requirements: obligations and violations (missing rights)<br>• Verify license compatibility under given circumstances |
+| Tasks            | • Assess license information from all packages (recent BoMs, infrastructure and 3rd party) and circumstances of use (business model, licensing amibition, IP protection requirements)<br>• Determine license obligations and potential violations |
+| Input            | • Composition analysis of all project related packages, their status (binding and modification status), and licenses<br>• Legal circumstances and requirements of the project |
+| Output           | • List of legal obligations and missing rights (if) by package and mitigation hints <br>• Information on license in-compatibility (yes, no, why?)  |
+| Comments         | • Independent from package status the analysis results may vary depending on changes in the circumstances. Thus analysis results should be versioned to allow allocation to related circumstances.<br>• How to handle jurisdiction specific decisions? Would this be the place to put the information? |

--- a/Tooling-Landscape/Capabilities/license_copyright_authors_scanner.md
+++ b/Tooling-Landscape/Capabilities/license_copyright_authors_scanner.md
@@ -1,0 +1,9 @@
+| License, Copyright & Authors Scanner         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Precise scanning of sources to determine exact situation for proper compliance declarations  |
+| Responsibilities | • Ensure completeness and correctness of compliance information  |
+| Tasks            | • Identify & gather copyright statements<br>• Identify & gather authors<br>• Identify & gather effective licenses (e.g. license identifier & if available license text)<br>• Identify & gather changes and / or additions to license terms  |
+| Input            | • Repository or file(s) to scan  |
+| Output           | • List of effective and declared licenses with links into code<br>• List of changed licenses with links into code<br>• List of copyright statements with links into code<br>• List of author information with links into code<br>• Status of processing (e.g. errors, inclompleteness, failures in processing) |
+| Comments         | • TODO: Clarify granularity required to differentiate between author, commiter and copyright holder
+ |

--- a/Tooling-Landscape/Capabilities/license_repository.md
+++ b/Tooling-Landscape/Capabilities/license_repository.md
@@ -1,0 +1,8 @@
+| License Repository         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Capture and archive legal information & interpretation about licenses |
+| Responsibilities | • Manage and provide legal information about known licenses |
+| Tasks            | • Capture & Update all license information including derived requirements and exceptions<br>• Provide reference for original license texts<br>• Provide environment to allow license analysis<br>• Track changes in license interpretation<br>• Manage classification and tagging  |
+| Input            | • License data + interpretations  |
+| Output           | • License data (updated) machine readable format  |
+| Comments         | • Could be combined with legal solver, but we decided to provide as separate capability. A solver requires the repository, but the solver also could be a human worker.<br>• How to represent different jurisdictions (e.g. case law UK / US)?=> probably overdone, stay with most restrictive interpretation to prevent failure|

--- a/Tooling-Landscape/Capabilities/management_3rd_party_components.md
+++ b/Tooling-Landscape/Capabilities/management_3rd_party_components.md
@@ -1,0 +1,8 @@
+| Management of 3rd party provided Components         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Manage Commercial-Off-The-Shelf (COTS) and infrastructure (open source or COTS) packages of a solution |
+| Responsibilities | • Allow tracking 3rd party components concerning vulnerability and compliance<br>• Collect and provide meta data for 3rd party or infrastructure packages |
+| Tasks            | • Store package metadata or 3rd party components and quality verification status (of that metadata concenring completeness and correctness)<br>• Store information about 3rd party/private commercial conditions (license information)<br>• Allow to assemble reports like SOUP-lists<br>• Optional: Review 3rd party assemblies for known vulnerabilities |
+| Input            | • Package data and metadata (if known)<br>• Binary scan information (BoM) |
+| Output           | • Package data and metadata (updated)<br>• License information about 3rd party components  |
+| Comments         | • PLEASE NOTE: For full compliance a storage for 3rd party sources/binaries should be available and referenceable<br>• PLEASE NOTE: Commercial Licenses may have different aspects involved like termination by time / renewable<br>• SOUP lists will require  additional meta information, which is not in the scope of open source components |

--- a/Tooling-Landscape/Capabilities/osg_rule_enforcement.md
+++ b/Tooling-Landscape/Capabilities/osg_rule_enforcement.md
@@ -1,0 +1,10 @@
+| (CI/CD) OSG Rule Enforcement         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Ensure only compliant artifacts will leave the automated tool chain   |
+| Responsibilities | • Break build, deployment or packaging as long as compliance violations exist  |
+| Tasks            | • Verify compliance state <br>• Interrupt automated build/deployment processing in case of violations<br>• Log event and causes<br>• Alert   |
+| Input            | • Automation event  |
+| Output           | • „Confirmation“ or „break“ event – or any sort of recording of required action<br>• Log entry  |
+| Comments         | • The key of this is to ensure that no non-compliant artifact will leave the process. It must not be CI/CD driven, but it should ensure that a check happens |
+
+OSG = Open Source Governance

--- a/Tooling-Landscape/Capabilities/package_archive.md
+++ b/Tooling-Landscape/Capabilities/package_archive.md
@@ -1,0 +1,8 @@
+| Package Archive          | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Longterm immutable storage of artefacts |
+| Responsibilities | • Collect and provide accurate information about the component <br>• Alert, if component can’t be matched/found  |
+| Tasks            | • Accept payload (sources of project or component) for longterm storage<br>• Create and provide unique reference to payload<br>• Allow download of sources<br>• Prevent / detect modification of sources<br>• Source storage objects automatically  |
+| Input            | • component reference, name or repository URL<br>• key    |
+| Output           | • Key<br>• Sources associated with key    |
+| Comments         |   |

--- a/Tooling-Landscape/Capabilities/package_crawler_finder.md
+++ b/Tooling-Landscape/Capabilities/package_crawler_finder.md
@@ -1,0 +1,8 @@
+| Package Crawler/Finder          | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Research information on (new) components such as locate the repository, current and former versions, project homepage and viability information          |
+| Responsibilities | • Collect and provide accurate information about the component <br>• Alert, if component can’t be matched/found  |
+| Tasks            | • Scan package managers for new packages or versions of packages<br>• Collect package data<br>• Transfer data into package repository  |
+| Input            | • Component descriptor or component name            |
+| Output           | • Component Information, such as: source repository url, version history, branches, commit count, stars, last commit date, etc.          |
+| Comments         | => Distinguish between component loader & assessment or just cralwer for information    |

--- a/Tooling-Landscape/Capabilities/package_metadata_repository.md
+++ b/Tooling-Landscape/Capabilities/package_metadata_repository.md
@@ -1,0 +1,8 @@
+| Package Metadata Repository         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Collect package information and clearing metadata on packages   |
+| Responsibilities | • Single point of truth for package information |
+| Tasks            | • Store package metadata and quality verification status (of that metadata concenring completeness and correctness)<br>• Support composition analysis (verification of dependency analysis)<br>• Provide search capabilities to identify existing packages<br>• Support authentication/authorization to ensure responsible data handling/editing  |
+| Input            | • Package identifier (e.g. purl) + already identified metadata<br>• Package metadata   |
+| Output           | • Package metadata, including package type (e.g. OSS, COTS, internal) and completion/ verification status of associated metadata<br>• Containment structures (consists of)<br>• Dependency structures (depends on)<br>• Optional: relate known vulnerability information (not OSC specific, but a good place) |
+| Comments         | • Archive should be provided by archive capability. Tools supporting both functions in one are not limited by the capabilities beeing separate. |

--- a/Tooling-Landscape/Capabilities/policies_rules.md
+++ b/Tooling-Landscape/Capabilities/policies_rules.md
@@ -1,0 +1,8 @@
+| Policies & Rules         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Capturing the Organisation specific interpretation of its obligations, objectives & goals |
+| Responsibilities | • Represent the rules derived from organisations legal understanding |
+| Tasks            | • Rules how to treat specific legal circumstances, e.g. commercial aspects, trade secrets or IP protection requirements, etc. <br>• Translate human readable policies to machine readable instructions/rules (as input input for analysis)<br>• Document / Track changes in project specific allow- lists or deny-lists (licenses, components, frameworks, etc.)<br>• Allow managing groups of projects with consistent policies & rules<br>• Optional: Store open source policy for reference |
+| Input            | • Legal requirements for particular application scenarios<br>• Definition allow- and deny-lists <br>• Project specific rules and policies (e.g. versions, OpenSSF Score, specific components, viability, etc.)  |
+| Output           | • History of changes  |
+| Comments         |  |

--- a/Tooling-Landscape/Capabilities/reporting_analytics.md
+++ b/Tooling-Landscape/Capabilities/reporting_analytics.md
@@ -1,0 +1,10 @@
+| Reporting & Analytics         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Visualize current work status, todos, <span style="color:red">effort spent</span> and success of compliance initiative |
+| Responsibilities | • Provide insights into state of portfolio<br>•Create overview of workload and help to assign priorities<br>• Measure compliance related activity |
+| Tasks            | • Collect data from different capabilities to allow reporting<br>• Report design  |
+| Input            | • Report specific data required  |
+| Output           | • Reports (human AND machine readable format)<br>• Transparency  |
+| Comments         | • Specific reports should be defined on org level<br>• See Todo Group for potential KPI ideas , e.g. scans/period, num of products scanned, number of issues found , etc.|
+
+

--- a/Tooling-Landscape/Capabilities/snippet_similarity_scanner.md
+++ b/Tooling-Landscape/Capabilities/snippet_similarity_scanner.md
@@ -1,0 +1,8 @@
+| Snippet & Similarity Scanner         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Identify pieces of original code (source, object, binary) by comparing against known codebase   |
+| Responsibilities | • Ensure code is free from copyright infringements due to copying routines or third party code<br>• Discover re-use of code <br>• Determine modification of identified code |
+| Tasks            | • Scan files for copies <br>• Scan sources for known snippets<br>• Provide scan results including references to copies/identified origin (e.g. earliest known appearance) |
+| Input            | • Repository or file(s) to scan<br>• Comparison basis (known data sets)   |
+| Output           | • List of potential infringements with links to potential matches (e.g. in existing OSS)<br>• Weighting/ordering of potential matches |
+| Comments         | • Snippet Scanning (e.g. plagiarism check), similarity scanning (rough check) and delta analysis (identify change) serve different purposes <br>• While similarity analysis gives indication that something might require further analysis, Snippet scanning delivers proof of re-use<br>• Similarity analysis also allows delta analysis to be performed |

--- a/Tooling-Landscape/Capabilities/tool_orchestrator.md
+++ b/Tooling-Landscape/Capabilities/tool_orchestrator.md
@@ -1,0 +1,10 @@
+| Tool Orchestrator         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Co-ordinate overall compliance workflow(s)  |
+| Responsibilities | • Arrange combination of tools to cope with compliance challenge <br>• Handle handover between capabilities |
+| Tasks            | • Trigger events   |
+| Input            | • Events  |
+| Output           | • Event  |
+| Comments         | • Depending on the degree of process automation the orchestrator may be a combination of event driven rule engine or a ticket system|
+
+

--- a/Tooling-Landscape/Capabilities/user_role_management.md
+++ b/Tooling-Landscape/Capabilities/user_role_management.md
@@ -1,0 +1,10 @@
+| User & Role Management         | |
+| ---------------- | ------------------------------------------------ |
+| Mission          | • Provide role based authorization |
+| Responsibilities | • Authenticate users<br>• Manage and/or map roles and authorizations<br>• Assign users to roles |
+| Tasks            | • Identify users (Login, oAuth, MFA)<br>• Manage roles and related authorizations (permissions assigned to roles)<br>• Manage programmatical access (e.g. API keys) |
+| Input            | • Users<br>• Roles   |
+| Output           | • Authenticated user and associated roles (e.g. via access token)  |
+| Comments         | • Agreement that these „infrastructural capabilities“ should be added and described|
+
+TODO: Provide support for infrastructural services to other capabilities


### PR DESCRIPTION
Transferred the capability slide contents 1:1 from OC_ToolingChain_v1.5.7.pptx V1.5.8 to MD-files for easier handling and feedback. Tagging with "agreed" checkbox was not taken over but would need to be tagged in the repository.
The MD-Files are stored in a separate folder next to the folder with the map.
The MD-files do not contain a dedicated License nor any copyright as it is a mere transformation of the existing contents of the PPT-content into Markdown.