### PR TITLE
URL to OSS Review Toolkit Github repository corrected

### DIFF
--- a/docs/Tooling-Landscape/OSS-Based-License-Compliance-Tools.md
+++ b/docs/Tooling-Landscape/OSS-Based-License-Compliance-Tools.md
@@ -262,7 +262,7 @@ OSS Discovery finds the open source software embedded in applications and instal
 
 ## OSS Review Toolkit ORT
 **Website:**
-[ORT](https://github.com/heremaps/oss-review-toolkit)<br>
+[ORT](https://github.com/oss-review-toolkit/ort)<br>
 **Main License:**
 [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)<br>
 **Summary:**<br>


### PR DESCRIPTION
There was still the old Heremaps URL in the list instead of the new ort-URL as it is a LF project now.