### PR TITLE
Update BomLens link to renamed repository (sktelecom/bomlens)

### DIFF
--- a/docs/Tooling-Landscape/OSS-Based-License-Compliance-Tools.md
+++ b/docs/Tooling-Landscape/OSS-Based-License-Compliance-Tools.md
@@ -76,7 +76,7 @@ Binary Analysis Next Generation, or BANG, is a tool for analyzing binary files. 
 
 
 ## BomLens
-**Website:**[BomLens](https://sktelecom.github.io/sbom-tools/)<br>
+**Website:**[BomLens](https://sktelecom.github.io/bomlens/)<br>
 **Main License:**
 [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)<br>
 **Summary:**<br>


### PR DESCRIPTION
The BomLens repository was renamed from `sktelecom/sbom-tools` to `sktelecom/bomlens`. This updates the documentation website link to the new path. The old URL still 301-redirects, but the direct link is clearer.